### PR TITLE
Pass --verbose flag to SwiftFormat 

### DIFF
--- a/Scripts/lint
+++ b/Scripts/lint
@@ -2,4 +2,4 @@
 
 swiftlint lint Stopwatch Tests UITests
 
-./Pods/SwiftFormat/CommandLineTool/swiftformat --exclude Pods --lint ..
+./Pods/SwiftFormat/CommandLineTool/swiftformat --exclude Pods --lint --verbose ..

--- a/Scripts/lint
+++ b/Scripts/lint
@@ -2,4 +2,4 @@
 
 swiftlint lint Stopwatch Tests UITests
 
-./Pods/SwiftFormat/CommandLineTool/swiftformat --exclude Pods --lint --verbose ..
+./Pods/SwiftFormat/CommandLineTool/swiftformat --lint --verbose --exclude Pods ..

--- a/Stopwatch/UI Components/LapTable.swift
+++ b/Stopwatch/UI Components/LapTable.swift
@@ -2,13 +2,13 @@ import Foundation
 import UIKit
 
 class LapTable: Table {
-    let counter: LapCounter;
+    let counter: LapCounter
 
     init(dataSource: LapCounter = LapCounter()) {
         // Hold a more narrowly-typed reference to the dataSource here
         // So it can have a specifically typed insert func, not e.g. Any-typed
         // on the TableDataSource protocol.
-        counter = dataSource;
+        counter = dataSource
         super.init(dataSource: dataSource)
     }
 

--- a/Stopwatch/UI Components/Table.swift
+++ b/Stopwatch/UI Components/Table.swift
@@ -1,9 +1,8 @@
 /*
-    This is a generic table that can render data from any class implementing
-    the TableDataSource protocol.
+ This is a generic table that can render data from any class implementing
+ the TableDataSource protocol.
 
-
-*/
+ */
 
 import Foundation
 import SnapKit

--- a/StopwatchApp.xcodeproj/project.pbxproj
+++ b/StopwatchApp.xcodeproj/project.pbxproj
@@ -35,7 +35,6 @@
 		5CFE5653225C7ACA008D30E6 /* format in Resources */ = {isa = PBXBuildFile; fileRef = 5CFE5652225C7ACA008D30E6 /* format */; };
 		697E78E04A5E3C03839F3FBF /* Pods_UITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F718E5E62C4D19C75B285B02 /* Pods_UITests.framework */; };
 		6B4BEBCB830DFD22D4213582 /* Pods_Stopwatch.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CD6A762482E91DC0F230647F /* Pods_Stopwatch.framework */; };
-		A21D719D658B0DADF8EFD7E5 /* Pods_StopwatchTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7259E1F90EC5308C41FEDFD5 /* Pods_StopwatchTests.framework */; };
 		D8BF822615DFF49AEFF88D0B /* Pods_Stopwatch.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CD6A762482E91DC0F230647F /* Pods_Stopwatch.framework */; };
 /* End PBXBuildFile section */
 
@@ -131,7 +130,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				A21D719D658B0DADF8EFD7E5 /* Pods_StopwatchTests.framework in Frameworks */,
 				0F0F26D6B7A361AE5B8DFC0A /* Pods_Tests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -779,13 +777,13 @@
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = "";
-				INFOPLIST_FILE = StopwatchTests/Info.plist;
+				INFOPLIST_FILE = Tests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = dgc.StopwatchTests;
+				PRODUCT_BUNDLE_IDENTIFIER = dgc.StopwatchApp.Tests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -801,13 +799,13 @@
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = "";
-				INFOPLIST_FILE = StopwatchTests/Info.plist;
+				INFOPLIST_FILE = Tests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = dgc.StopwatchTests;
+				PRODUCT_BUNDLE_IDENTIFIER = dgc.StopwatchApp.Tests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";


### PR DESCRIPTION
so it tells you which files need to be formatted.

Not sure about this, because it produces a bunch of output for files there don't need anything!

Ideally `swiftformat --lint --format` would only produce output for files that need changes.

I might also try actually running the formatter and then doing a `git diff`, which seems more useful!