### PR TITLE
Make CircleCI SwiftFormat job verbose

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,7 +73,7 @@ jobs:
 
       - run:
           name: Verify that running SwiftFormat doesn't change anything
-          command: ./Pods/SwiftFormat/CommandLineTool/swiftformat --exclude Pods --lint .
+          command: ./Pods/SwiftFormat/CommandLineTool/swiftformat --exclude Pods --lint --verbose .
 
 workflows:
   version: 2


### PR DESCRIPTION
Circle actually doesn't call Scripts/lint because that does both SwiftFormat and SwiftLint and the circle job only wants SwiftFormat.

This makes the SwiftFormat output in CircleCI verbose so you can see which files need formatting changes.